### PR TITLE
Update loofah and rack for CVEs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ gem 'jbuilder', '~> 2.5'
 gem 'bcrypt', '~> 3.1.7'
 gem 'strong_password', '~> 0.0.6'
 
+gem "loofah", ">= 2.2.3"
+gem "rack", ">= 2.0.6"
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (10.0.2)
-    capybara (3.10.0)
+    capybara (3.11.1)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -66,7 +66,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.3)
     crass (1.0.4)
     database_cleaner (1.7.0)
     diff-lcs (1.3)
@@ -79,7 +79,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
-    jbuilder (2.7.0)
+    jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
     launchy (2.4.3)
@@ -88,14 +88,14 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    method_source (0.9.0)
+    method_source (0.9.2)
     mimemagic (0.3.2)
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
@@ -108,7 +108,7 @@ GEM
     pg (1.1.3)
     public_suffix (3.0.3)
     puma (3.12.0)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.1)
@@ -143,7 +143,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    regexp_parser (1.2.0)
+    regexp_parser (1.3.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.2)
@@ -162,7 +162,7 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
     ruby_dep (1.5.0)
-    sass (3.6.0)
+    sass (3.7.2)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -183,12 +183,12 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     strong_password (0.0.6)
-    thor (0.20.0)
+    thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.8)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    uglifier (4.1.19)
+    uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
     web-console (3.7.0)
       actionview (>= 5.0)
@@ -215,8 +215,10 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   launchy
   listen (>= 3.0.5, < 3.2)
+  loofah (>= 2.2.3)
   pg (>= 0.18, < 2.0)
   puma (~> 3.11)
+  rack (>= 2.0.6)
   rails (~> 5.2.0)
   rails-controller-testing
   rspec-rails (~> 3.7)
@@ -231,4 +233,4 @@ RUBY VERSION
    ruby 2.4.0p0
 
 BUNDLED WITH
-   1.16.4
+   1.17.1


### PR DESCRIPTION
GitHub security alerts was warning us about the loofah and rack gems:
* https://github.com/meyerhoferc/secret-santa/network/alert/Gemfile.lock/loofah/open
* https://github.com/meyerhoferc/secret-santa/network/alert/Gemfile.lock/rack/open

Changes are limited to the Gemfile and Gemfile.lock. You will probably need to run `bundle update` to get this work locally. All tests pass