### PR TITLE
Form improvement

### DIFF
--- a/app/assets/stylesheets/base.css
+++ b/app/assets/stylesheets/base.css
@@ -24,8 +24,10 @@ html {
 }
 
 body {
+  background: linear-gradient(to top, #9cb6d9 15%, #a7e4f2) fixed;
   background: linear-gradient(to top, var(--background-primary) 15%, var(--background-secondary)) fixed;
   background-repeat: no-repeat;
+  color: #e9ebf2;
   color: var(--text);
   font-family: 'cabin-regular', sans-serif;
 }
@@ -68,16 +70,28 @@ a,
 }
 
 a {
+  color: #bdf2ed;
   color: var(--link);
   border-radius: 3px;
 }
 
 a:hover {
+  color: #e9ebf2;
   color: var(--text);
 }
 
 .required {
+  color: #f50;
   color: var(--warning);
-  cursor: help;
   font-size: 1.2rem;
+  font-weight: bold;
+}
+
+.small {
+  font-size: 0.8rem;
+}
+
+.help-text {
+  color: #cbd5d2;
+  color: var(--form-input-background);
 }

--- a/app/assets/stylesheets/base.css
+++ b/app/assets/stylesheets/base.css
@@ -95,3 +95,18 @@ a:hover {
   color: #cbd5d2;
   color: var(--form-input-background);
 }
+
+.button {
+  text-decoration: none;
+  background-color: #2da7c7;
+  background-color: var(--button-background);
+  border: 4px solid #2da7c7;
+  border: 4px solid var(--button-background);
+  padding: 10px;
+  border-radius: 3px;
+}
+
+.button:hover {
+  background-color: #037f8c;
+  background-color: var(--button-background-hover);
+}

--- a/app/assets/stylesheets/dashboard.css
+++ b/app/assets/stylesheets/dashboard.css
@@ -78,8 +78,11 @@
 .reply a {
   box-sizing: border-box;
   text-decoration: none;
+  color: #e9ebf2;
   color: var(--text);
+  background-color: #2da7c7;
   background-color: var(--button-background);
+  border: 4px solid #2da7c7;
   border: 4px solid var(--button-background);
   padding: 10px;
   border-radius: 3px;
@@ -87,6 +90,7 @@
 }
 
 .reply a:hover {
+  background-color: #037f8c;
   background-color: var(--button-background-hover);
 }
 

--- a/app/assets/stylesheets/flash-message.css
+++ b/app/assets/stylesheets/flash-message.css
@@ -1,5 +1,6 @@
 .warning,
 .notice {
+  background: #1f5aa6;
   background: var(--background-text-primary);
   display: block;
   text-align: center;
@@ -16,9 +17,11 @@
 }
 
 .notice {
+  border: 3px solid #0f0;
   border: 3px solid var(--notice);
 }
 
 .warning {
+  border: 3px solid #f50;
   border: 3px solid var(--warning);
 }

--- a/app/assets/stylesheets/forms.css
+++ b/app/assets/stylesheets/forms.css
@@ -82,7 +82,9 @@
 .form-field input,
 .form-field select {
   font-size: 1.2rem;
+  color: #030406;
   color: var(--form-input);
+  background-color: #cbd5d2;
   background-color: var(--form-input-background);
   height: 40px;
   border: none;
@@ -95,6 +97,7 @@
 .form-field textarea,
 .form-field input {
   width: 330px;
+  caret-color: #030406;
   caret-color: var(--form-input);
 }
 
@@ -108,8 +111,11 @@
   -moz-appearance: none;
   appearance: none;
   font-size: 1.2rem;
+  color: #e9ebf2;
   color: var(--text);
+  background-color: #2da7c7;
   background-color: var(--button-background);
+  border: 4px solid #2da7c7;
   border: 4px solid var(--button-background);
   padding: 10px;
   border-radius: 3px;
@@ -117,11 +123,14 @@
 }
 
 .form-submit input:hover {
+  background-color: #037f8c;
   background-color: var(--button-background-hover);
 }
 
 .form-submit input:disabled {
+  background-color: #a3a19f;
   background-color: var(--border);
+  border: 4px solid #a3a19f;
   border: 4px solid var(--border);
   cursor: not-allowed;
 }

--- a/app/assets/stylesheets/grid.css
+++ b/app/assets/stylesheets/grid.css
@@ -14,8 +14,10 @@
   max-width: 850px;
   min-height: 400px;
   margin: 50px auto 0 auto;
+  background: linear-gradient(to top, #1f5aa6 25%, #3b74bf);
   background: linear-gradient(to top, var(--background-text-primary) 25%, var(--background-text-secondary));
   background-repeat: no-repeat;
+  border: 6px solid #a3a19f;
   border: 6px solid var(--border);
   border-radius: 3px;
 }
@@ -42,7 +44,9 @@
 .items-data,
 .items-modify,
 .items-profile-link {
+  border: 2px solid #a3a19f;
   border: 2px solid var(--border);
+  background-color: #3b74bf;
   background-color: var(--background-text-secondary);
   border-radius: 3px;
   padding: 10px;

--- a/app/assets/stylesheets/groups.css
+++ b/app/assets/stylesheets/groups.css
@@ -133,6 +133,7 @@
 }
 
 .groups-santa-exclusion-team {
+  border: 2px solid #a3a19f;
   border: 2px solid var(--border);
   border-radius: 3px;
   margin: 10px 0;

--- a/app/assets/stylesheets/navbar.css
+++ b/app/assets/stylesheets/navbar.css
@@ -1,4 +1,5 @@
 .navbar-container {
+  background-color: #1f5aa6;
   background-color: var(--background-text-primary);
   height: 65px;
 }
@@ -15,8 +16,11 @@
 .navbar-groups,
 .navbar-links > a {
   font-size: 1.25rem;
+  color: #e9ebf2;
   color: var(--text);
+  background-color: #2da7c7;
   background-color: var(--button-background);
+  border: 4px solid #2da7c7;
   border: 4px solid var(--button-background);
   padding: 10px;
   border-radius: 3px;
@@ -27,6 +31,7 @@
 
 .navbar-groups:hover,
 .navbar-links > a:hover {
+  background-color: #037f8c;
   background-color: var(--button-background-hover);
 }
 
@@ -51,7 +56,9 @@
   position: absolute;
   flex-direction: column;
   justify-content: space-evenly;
+  background-color: #3b74bf;
   background-color: var(--background-text-secondary);
+  border: 4px solid #a3a19f;
   border: 4px solid var(--border);
   margin-left: -10px;
   max-width: 450px;

--- a/app/assets/stylesheets/spacing.css
+++ b/app/assets/stylesheets/spacing.css
@@ -1,3 +1,7 @@
+.mt0_5 {
+  margin-top: 0.5rem;
+}
+
 .mt1 {
   margin-top: 1rem;
 }
@@ -8,6 +12,10 @@
 
 .mt3 {
   margin-top: 3rem;
+}
+
+.mb0_5 {
+  margin-bottom: 0.5rem;
 }
 
 .mb1 {
@@ -22,6 +30,10 @@
   margin-bottom: 3rem;
 }
 
+.pt0_5 {
+  padding-top: 0.5rem;
+}
+
 .pt1 {
   padding-top: 1rem;
 }
@@ -32,6 +44,10 @@
 
 .pt3 {
   padding-top: 3rem;
+}
+
+.pb0_5 {
+  padding-bottom: 0.5rem;
 }
 
 .pb1 {

--- a/app/assets/stylesheets/spacing.css
+++ b/app/assets/stylesheets/spacing.css
@@ -1,0 +1,47 @@
+.mt1 {
+  margin-top: 1rem;
+}
+
+.mt2 {
+  margin-top: 2rem;
+}
+
+.mt3 {
+  margin-top: 3rem;
+}
+
+.mb1 {
+  margin-bottom: 1rem;
+}
+
+.mb2 {
+  margin-bottom: 2rem;
+}
+
+.mb3 {
+  margin-bottom: 3rem;
+}
+
+.pt1 {
+  padding-top: 1rem;
+}
+
+.pt2 {
+  padding-top: 2rem;
+}
+
+.pt3 {
+  padding-top: 3rem;
+}
+
+.pb1 {
+  padding-bottom: 1rem;
+}
+
+.pb2 {
+  padding-bottom: 2rem;
+}
+
+.pb3 {
+  padding-bottom: 3rem;
+}

--- a/app/assets/stylesheets/welcome.css
+++ b/app/assets/stylesheets/welcome.css
@@ -30,7 +30,9 @@
 .welcome-login a,
 .welcome-signup a {
   text-decoration: none;
+  background-color: #2da7c7;
   background-color: var(--button-background);
+  border: 4px solid #2da7c7;
   border: 4px solid var(--button-background);
   padding: 10px;
   border-radius: 3px;
@@ -38,5 +40,6 @@
 
 .welcome-login a:hover,
 .welcome-signup a:hover {
+  background-color: #037f8c;
   background-color: var(--button-background-hover);
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,6 +16,6 @@ module ApplicationHelper
   end
 
   def required_label_maker(text)
-    "#{text} <span class=\"required\" title=\"Field is required\">*</span>".html_safe
+    "#{text} <span class=\"required\" title=\"#{text} is required\">*</span>".html_safe
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ApplicationRecord
   validates_format_of :username, with: /\A\w{1,}\z/i, message: 'must contain only letters, numbers or underscores'
   validates_uniqueness_of :email, allow_blank: true, case_sensitive: false
   has_secure_password
-  validates :password, password_strength: { use_dictionary: true, min_entropy: 15 }, if: :should_validate_password?
+  validates :password, password_strength: { use_dictionary: true, min_entropy: 12 }, if: :should_validate_password?
 
   def full_name
     "#{first_name} #{last_name}"

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -16,5 +16,12 @@
         <%= submit_tag "Log In" %>
       </div>
     <% end %>
+
+    <div class="mt2 mb2 form-field">
+        <p>
+          Don't have an account?
+          <%= link_to "Sign up here", signup_path %>
+        </p>
+    </div>
   </div>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,4 +1,4 @@
-<div class="form-container">
+<div class="form-container mb2">
   <div class="form-title">
     <h1>Sign Up</h1>
   </div>
@@ -26,7 +26,7 @@
         Password must be at least 12 characters long
       </div>
     </div>
-    <div class="form-field">
+    <div class="form-field mb1">
       <%= f.label :password_confirmation, required_label_maker('Password confirmation') %>
       <%= f.password_field :password_confirmation %>
     </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -22,6 +22,9 @@
     <div class="form-field">
       <%= f.label :password, required_label_maker('Password') %>
       <%= f.password_field :password %>
+      <div class="small help-text">
+        Password must be at least 12 characters long
+      </div>
     </div>
     <div class="form-field">
       <%= f.label :password_confirmation, required_label_maker('Password confirmation') %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -19,7 +19,7 @@
       <%= f.label :email %>
       <%= f.email_field :email %>
     </div>
-    <div class="form-field">
+    <div class="form-field mb0_5">
       <%= f.label :password, required_label_maker('Password') %>
       <%= f.password_field :password %>
       <div class="small help-text">

--- a/spec/features/users/user_can_signup_spec.rb
+++ b/spec/features/users/user_can_signup_spec.rb
@@ -12,6 +12,7 @@ describe 'user signup' do
       fill_in('user[username]', with: user[:username])
       fill_in('user[email]', with: user[:email])
       fill_in('user[password]', with: user[:password])
+      expect(page).to have_text 'Password must be at least 12 characters long'      
       fill_in('user[password_confirmation]', with: user[:password])
       expect(page).to have_link 'Home'
       click_on 'Create User'
@@ -19,6 +20,7 @@ describe 'user signup' do
       expect(current_path).to eq login_path
       fill_in('Username or email', with: user[:email])
       fill_in('Password', with: user[:password])
+      expect(page).to have_link 'Sign up here'
       click_on 'Log In'
 
       expect(current_path).to eq dashboard_path


### PR DESCRIPTION
# Form improvements

* Adds helper text to the sign up form to inform the user of the password length requirement. The password `min_entropy` has been changed from 15 to 12 for ease of use.

* Adds a link to `Sign up here` if a user clicks "Log in" instead of "Sign up".

* Modified CSS files to include color fallbacks for browsers that don't support CSS variables (primarily Internet Explorer).

* Adds few test expectations added to verify text and link are visible on the signup and login page.