### PR TITLE
Page titles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,4 +18,12 @@ module ApplicationHelper
   def required_label_maker(text)
     "#{text} <span class=\"required\" title=\"#{text} is required\">*</span>".html_safe
   end
+
+  def page_title(text)
+    if text.present?
+      "#{text} - Secret Santa".html_safe
+    else
+      "Secret Santa"
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,11 @@ class User < ApplicationRecord
     "#{first_name} #{last_name}"
   end
 
+  def full_name_possessive
+    name = full_name
+    "#{name}'#{'s' if name[-1] != 's'}"
+  end
+
   def should_validate_password?
     new_record? || !skip_pass_strength
   end

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title, 'Dashboard') %>
 <div class="dashboard-container">
   <% if current_user %>
     <div class="dashboard-title">
@@ -16,7 +17,7 @@
               <div class="dashboard-invitations-each-invite">
                 <div class="greeting">
                   <% user = User.find(invitation.sender_id) %>
-                  <%= link_to "#{user.first_name} #{user.last_name}", user_path(invitation.sender_id) %><%= " has invited you to join the group "%><%= link_to "#{group.name}!", group_path(group.id) %>
+                  <%= link_to "#{user.full_name}", user_path(invitation.sender_id) %><%= " has invited you to join the group "%><%= link_to "#{group.name}!", group_path(group.id) %>
                 </div>
                 <% if invitation.comment %>
                   <div class="comment">

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title, "Edit #{@group.name}") %>
 <div class="form-container">
   <div class="form-title">
     <h1>Edit: <%= "#{@group.name}" %></h1>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title, 'Create a Group') %>
 <div class="form-container">
   <div class="form-title">
     <h1>Create a Group</h1>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title, @group.name) %>
 <div class="groups-container">
   <div class="groups-title">
     <h1><%= @group.name %></h1>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title, "Edit #{@item.name}") %>
 <div class="items-edit-container">
   <div class="items-title">
     <h1>Edit: <%= "#{@item.name}" %></h1>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title, "#{@item.name}") %>
 <div class="items-container">
   <div class="items-title">
     <h1>Details for <%= "#{@item.name}" %></h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Secret Santa</title>
+    <title><%= page_title(yield(:title)) %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/lists/edit.html.erb
+++ b/app/views/lists/edit.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title, "Edit Private Message") %>
 <div class="form-container">
   <div class="form-title">
     <h1>Edit: Private Message for Your Secret Santa</h1>

--- a/app/views/lists/new.html.erb
+++ b/app/views/lists/new.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title, "New Private Message") %>
 <div class="form-container">
   <div class="form-title">
     <h1>Add a Private Message for Your Secret Santa</h1>

--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -1,10 +1,11 @@
+<% provide(:title, "#{@user.full_name_possessive} Wish List'") %>
 <div class="lists-container">
   <div class="lists-title">
-    <h1><%= "#{@user.first_name} #{@user.last_name}'s Wish List" %></h1>
+    <h1><%= "#{@user.full_name_possessive} Wish List" %></h1>
   </div>
   <div class="lists-links">
     <%= link_to "#{@group.name}", group_path(@group.id) %>
-    <%= link_to "#{@user.first_name} #{@user.last_name}'s profile", user_path(@user) %>
+    <%= link_to "#{@user.full_name_possessive} profile", user_path(@user) %>
   </div>
   <% santa = User.find(@user.santa_recipient.find_by(group_id: @group.id).santa_id) if @group.santas_assigned %>
   <% if @group.santas_assigned && authorized_user(santa) %>
@@ -44,7 +45,7 @@
       </div>
       <% end %>
     <% else %>
-      <%= "#{@user.first_name} #{@user.last_name}'s list is empty." %>
+      <%= "#{@user.full_name_possessive} list is empty." %>
     <% end %>
   </div>
 </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title, "Log In") %>
 <div class="form-container">
   <div class="form-title">
     <h1>Log In</h1>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title, "Edit Profile") %>
 <div class="user-update-form-container">
   <div class="form-title">
     <h1>Edit: Your Profile</h1>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title, "Sign Up") %>
 <div class="form-container mb2">
   <div class="form-title">
     <h1>Sign Up</h1>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,11 +1,12 @@
+<% provide(:title, "#{@user.full_name_possessive} Profile") %>
 <div class="users-container">
   <div class="users-title">
-    <h1><%= "#{@user.first_name} #{@user.last_name}'s Profile" %></h1>
+    <h1><%= "#{@user.full_name_possessive} Profile" %></h1>
   </div>
   <div class="users-data">
     <div class="users-information">
       <p>
-        Name: <%= "#{@user.first_name} #{@user.last_name}" %>
+        Name: <%= "#{@user.full_name}" %>
       </p>
       <p>
         Username: <%= @user.username %>
@@ -21,7 +22,7 @@
     </div>
     <% if !authorized_user(@user) && !@invitable_groups.empty? %>
       <div class="users-group-invitation">
-        <h3>Invite <%= "#{@user.first_name} #{@user.last_name}" %> to a Group</h3>
+        <h3>Invite <%= "#{@user.full_name}" %> to a Group</h3>
         <%= render partial: 'invitations/user_profile_form' %>
       </div>
     <% end %>

--- a/spec/features/groups/creating_group_spec.rb
+++ b/spec/features/groups/creating_group_spec.rb
@@ -49,7 +49,7 @@ describe 'group creation' do
       expect(page).to have_content group.description
       expect(page).to have_content group.gift_due_date.to_formatted_s(:long_ordinal)
       expect(page).to have_content 'Edit', 'Delete'
-      expect(page).to have_content "#{user.first_name} #{user.last_name}:"
+      expect(page).to have_content "#{user.full_name}:"
       expect(page).to have_content 'Send an invitation', 'My Wish List'
     end
 

--- a/spec/features/invitations/creating_invitation_spec.rb
+++ b/spec/features/invitations/creating_invitation_spec.rb
@@ -101,7 +101,7 @@ describe 'creating an invitation' do
             sign_out
 
             sign_in(invitee)
-            expect(page).to have_content "#{owner.first_name} #{owner.last_name} has invited you to join the group #{group.name}"
+            expect(page).to have_content "#{owner.full_name} has invited you to join the group #{group.name}"
             sign_out
 
             sign_in(owner)
@@ -128,7 +128,7 @@ describe 'creating an invitation' do
             sign_out
 
             sign_in(invitee)
-            expect(page).to have_content "#{owner.first_name} #{owner.last_name} has invited you to join the group #{group.name}"
+            expect(page).to have_content "#{owner.full_name} has invited you to join the group #{group.name}"
             click_on 'Accept'
             sign_out
 
@@ -155,7 +155,7 @@ describe 'creating an invitation' do
             sign_out
 
             sign_in(invitee)
-            expect(page).to have_content "#{owner.first_name} #{owner.last_name} has invited you to join the group #{group.name}"
+            expect(page).to have_content "#{owner.full_name} has invited you to join the group #{group.name}"
             click_on 'Decline'
             sign_out
 
@@ -174,7 +174,7 @@ describe 'creating an invitation' do
       click_on 'Create Group'
 
       visit user_path(owner.id)
-      expect(page).to have_no_content "Invite #{owner.first_name} #{owner.last_name} to a Group", 'Submit'
+      expect(page).to have_no_content "Invite #{owner.full_name} to a Group", 'Submit'
     end
 
     context 'with email' do
@@ -201,7 +201,7 @@ describe 'creating an invitation' do
         fill_in 'invitation[comment]', with: 'Would you like to join our great group?'
         click_on 'Submit'
 
-        expect(page).to have_content "#{owner.first_name} #{owner.last_name}:"
+        expect(page).to have_content "#{owner.full_name}:"
         expect(page).to have_content "Sender cannot send yourself an invitation"
       end
     end
@@ -230,7 +230,7 @@ describe 'creating an invitation' do
         fill_in 'invitation[comment]', with: 'Would you like to join our great group?'
         click_on 'Submit'
 
-        expect(page).to have_content "#{owner.first_name} #{owner.last_name}:"
+        expect(page).to have_content "#{owner.full_name}:"
         expect(page).to have_content "Sender cannot send yourself an invitation"
       end
 
@@ -282,7 +282,7 @@ describe 'creating an invitation' do
       sign_in(invitee)
 
       visit user_path(owner.id)
-      expect(page).to have_no_content "Invite #{owner.first_name} #{owner.last_name} to a Group", 'Submit'
+      expect(page).to have_no_content "Invite #{owner.full_name} to a Group", 'Submit'
     end
 
     context 'from group page' do

--- a/spec/features/invitations/replying_to_invitation_spec.rb
+++ b/spec/features/invitations/replying_to_invitation_spec.rb
@@ -20,7 +20,7 @@ describe 'replying to an invitation' do
     visit root_path
     sign_in(invitee)
     expect(current_path).to eq dashboard_path
-    expect(page).to have_content "#{owner.first_name} #{owner.last_name} has invited you to join the group #{group.name}!"
+    expect(page).to have_content "#{owner.full_name} has invited you to join the group #{group.name}!"
     expect(page).to have_content 'Accept', 'Decline'
     click_on 'Accept'
 
@@ -30,8 +30,8 @@ describe 'replying to an invitation' do
     page.all('a', exact_text: group.name, visible:true).last.click
 
     # might change over time
-    expect(page).to have_content "#{owner.first_name} #{owner.last_name}: Wish List"
-    expect(page).to have_content "#{invitee.first_name} #{invitee.last_name}:"
+    expect(page).to have_content "#{owner.full_name}: Wish List"
+    expect(page).to have_content "#{invitee.full_name}:"
     expect(page).to have_link 'My Wish List'
   end
 
@@ -48,7 +48,7 @@ describe 'replying to an invitation' do
 
     sign_in(invitee)
     expect(current_path).to eq dashboard_path
-    expect(page).to have_content "#{owner.first_name} #{owner.last_name} has invited you to join the group #{group.name}!"
+    expect(page).to have_content "#{owner.full_name} has invited you to join the group #{group.name}!"
     expect(page).to have_content 'Accept', 'Decline'
     click_on 'Decline'
 
@@ -77,7 +77,7 @@ describe 'owner sending multiple invites' do
 
       sign_in(invitee)
       expect(current_path).to eq dashboard_path
-      expect(page).to have_content "#{owner.first_name} #{owner.last_name} has invited you to join the group #{group.name}!"
+      expect(page).to have_content "#{owner.full_name} has invited you to join the group #{group.name}!"
       expect(page).to have_content 'Accept', 'Decline'
       click_on 'Decline'
       expect(page).to have_content 'Invitation declined'
@@ -93,7 +93,7 @@ describe 'owner sending multiple invites' do
 
       sign_out
       sign_in(invitee)
-      expect(page).to have_content "#{owner.first_name} #{owner.last_name} has invited you to join the group #{group.name}"
+      expect(page).to have_content "#{owner.full_name} has invited you to join the group #{group.name}"
     end
 
     it 'user accepting' do
@@ -109,7 +109,7 @@ describe 'owner sending multiple invites' do
 
       sign_in(invitee)
       expect(current_path).to eq dashboard_path
-      expect(page).to have_content "#{owner.first_name} #{owner.last_name} has invited you to join the group #{group.name}!"
+      expect(page).to have_content "#{owner.full_name} has invited you to join the group #{group.name}!"
       expect(page).to have_content 'Accept', 'Decline'
       click_on 'Accept'
       expect(page).to have_content 'Invitation accepted'
@@ -125,7 +125,7 @@ describe 'owner sending multiple invites' do
 
       sign_out
       sign_in(invitee)
-      expect(page).to have_no_content "#{owner.first_name} #{owner.last_name} has invited you to join the group #{group.name}!"
+      expect(page).to have_no_content "#{owner.full_name} has invited you to join the group #{group.name}!"
     end
   end
 
@@ -143,7 +143,7 @@ describe 'owner sending multiple invites' do
 
       sign_in(invitee)
       expect(current_path).to eq dashboard_path
-      expect(page).to have_content "#{owner.first_name} #{owner.last_name} has invited you to join the group #{group.name}!"
+      expect(page).to have_content "#{owner.full_name} has invited you to join the group #{group.name}!"
       expect(page).to have_content 'Accept', 'Decline'
       click_on 'Decline'
       expect(page).to have_content 'Invitation declined'
@@ -159,7 +159,7 @@ describe 'owner sending multiple invites' do
 
       sign_out
       sign_in(invitee)
-      expect(page).to have_content "#{owner.first_name} #{owner.last_name} has invited you to join the group #{group.name}"
+      expect(page).to have_content "#{owner.full_name} has invited you to join the group #{group.name}"
     end
 
     it 'user accepting' do
@@ -175,11 +175,11 @@ describe 'owner sending multiple invites' do
 
       sign_in(invitee)
       expect(current_path).to eq dashboard_path
-      expect(page).to have_content "#{owner.first_name} #{owner.last_name} has invited you to join the group #{group.name}!"
+      expect(page).to have_content "#{owner.full_name} has invited you to join the group #{group.name}!"
       expect(page).to have_content 'Accept', 'Decline'
       click_on 'Accept'
       expect(page).to have_content 'Invitation accepted'
-      expect(page).to have_no_content "#{owner.first_name} #{owner.last_name} has invited you to join the group #{group.name}!"
+      expect(page).to have_no_content "#{owner.full_name} has invited you to join the group #{group.name}!"
 
       sign_out
 
@@ -192,7 +192,7 @@ describe 'owner sending multiple invites' do
 
       sign_out
       sign_in(invitee)
-      expect(page).to have_no_content "#{owner.first_name} #{owner.last_name} has invited you to join the group #{group.name}!"
+      expect(page).to have_no_content "#{owner.full_name} has invited you to join the group #{group.name}!"
     end
   end
 
@@ -210,7 +210,7 @@ describe 'owner sending multiple invites' do
 
       sign_in(user)
       expect(current_path).to eq dashboard_path
-      expect(page).to have_no_content "#{owner.first_name} #{owner.last_name} has invited you to join the group #{group.name}!"
+      expect(page).to have_no_content "#{owner.full_name} has invited you to join the group #{group.name}!"
       expect(page).to have_no_content 'Accept', 'Decline'
       visit "/accept/#{invitee.invitations_received.first.id}"
       expect(page).to have_content 'Action is unauthorized'
@@ -230,7 +230,7 @@ describe 'owner sending multiple invites' do
 
       sign_in(user)
       expect(current_path).to eq dashboard_path
-      expect(page).to have_no_content "#{owner.first_name} #{owner.last_name} has invited you to join the group #{group.name}!"
+      expect(page).to have_no_content "#{owner.full_name} has invited you to join the group #{group.name}!"
       expect(page).to have_no_content 'Accept', 'Decline'
       visit "/decline/#{invitee.invitations_received.first.id}"
       expect(page).to have_content 'Action is unauthorized'


### PR DESCRIPTION
# Adds page titles

The project has been lacking any dynamic page titles and this PR adds them to each page. A helper method formats the text and uses a fallback if the argument is empty.

Also adds a `User` `full_name_possessive` method to render apostrophes correctly for a user's full name.