### PR TITLE
Group dollar limit

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -91,7 +91,7 @@ class GroupsController < ApplicationController
   end
 
   def group_params
-    params.require(:group).permit(:name, :description, :owner_id, :gift_due_date)
+    params.require(:group).permit(:name, :description, :owner_id, :gift_due_date, :dollar_limit)
   end
 
   def belonging_user(user_list)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,6 +15,10 @@ module ApplicationHelper
     text.join(', ').to_s
   end
 
+  def display_money(float)
+    "$#{format('%.2f', float)}"
+  end
+
   def required_label_maker(text)
     "#{text} <span class=\"required\" title=\"#{text} is required\">*</span>".html_safe
   end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -6,7 +6,9 @@ class Group < ApplicationRecord
   has_many :exclusion_teams
   has_many :santa_assignments
   belongs_to :owner, foreign_key: :owner_id, class_name: 'User'
+
   validates_uniqueness_of :name, message: 'is already in use.'
+  validates_numericality_of :dollar_limit, greater_than_or_equal_to: 0.01, allow_nil: true
   validates :name, presence: true
   validates :description, presence: true
   validates :owner_id, presence: true

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -8,8 +8,15 @@
     <%= f.text_area :description %>
   </div>
   <div class="form-field">
-    <%= f.label 'group', required_label_maker('Gift Due Date') %>
+    <%= f.label 'group', required_label_maker('Gift due date') %>
     <%= date_field 'group', 'gift_due_date', min: (action_name == 'new' ? Date.today : @group.created_at) %>
+  </div>
+  <div class="form-field">
+    <%= f.label :dollar_limit, 'Gift dollar limit' %>
+    <%= f.number_field :dollar_limit, min: 0.00, step: 0.01 %>
+    <div class="small help-text">
+      Set the price expectation for others
+    </div>
   </div>
   <div class="form-submit">
     <%= f.submit %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -16,7 +16,7 @@
     </div>
     <% if @group.dollar_limit.present? %>
       <div class="mb0_5">
-        <h4>Gift dollar limit: $<%= @group.dollar_limit %></h4>
+        <h4>Gift dollar limit: <%= display_money(@group.dollar_limit) %></h4>
       </div>
     <% end %>
     <% if @user_wish_list %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -14,6 +14,11 @@
     <div title="Due in <%= time_ago_in_words(@group.gift_due_date) %>">
       <h3>Gifts Due <%= @group.gift_due_date.to_formatted_s(:long_ordinal) %></h3>
     </div>
+    <% if @group.dollar_limit.present? %>
+      <div class="mb0_5">
+        <h4>Gift dollar limit: $<%= @group.dollar_limit %></h4>
+      </div>
+    <% end %>
     <% if @user_wish_list %>
       <div class="groups-wishlist-link">
         <%= link_to 'My Wish List', group_list_path(@group, @user_wish_list.id) %>

--- a/db/migrate/20191113050029_add_dollar_limit_to_groups.rb
+++ b/db/migrate/20191113050029_add_dollar_limit_to_groups.rb
@@ -1,0 +1,5 @@
+class AddDollarLimitToGroups < ActiveRecord::Migration[5.2]
+  def change
+    add_column(:groups, :dollar_limit, :decimal, precision: 1000, scale: 2, optional: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_06_040127) do
+ActiveRecord::Schema.define(version: 2019_11_13_050029) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 2019_11_06_040127) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean "santas_assigned", default: false
+    t.decimal "dollar_limit", precision: 1000, scale: 2
     t.index ["owner_id"], name: "index_groups_on_owner_id"
   end
 

--- a/spec/features/groups/creating_group_spec.rb
+++ b/spec/features/groups/creating_group_spec.rb
@@ -17,6 +17,21 @@ describe 'group creation' do
       expect(page).to have_content group_info.gift_due_date.to_formatted_s(:long_ordinal)
     end
 
+    it 'correct information with dollar limit' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      visit new_group_path
+      fill_in('group_name', with: group_info.name)
+      fill_in('group_description', with: group_info.description)
+      fill_in('group_gift_due_date', with: group_info.gift_due_date)
+      fill_in('group_dollar_limit', with: 23.47)
+      click_on 'Create Group'
+
+      expect(page).to have_content group_info.name
+      expect(page).to have_content group_info.description
+      expect(page).to have_content group_info.gift_due_date.to_formatted_s(:long_ordinal)
+      expect(page).to have_content display_money(23.47)
+    end
+
     it 'blank information' do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
       visit new_group_path

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -17,6 +17,11 @@ describe Group do
       expect(g.valid?).to eq false
     end
 
+    it 'validates dollar_limit is greater than 0.00' do
+      g = Group.new(name: 'This one Group', description: 'Here is a description', owner_id: 3, gift_due_date: '', dollar_limit: 0.00)
+      expect(g.valid?).to eq false
+    end
+
     it 'validates name is unique' do
       Group.create(name: 'This one Group', description: 'Here is a description', owner_id: 3, gift_due_date: '2018/12/31')
       g = Group.new(name: 'This one Group', description: 'Here is a description', owner_id: 3, gift_due_date: '2018/12/31')
@@ -75,6 +80,8 @@ describe Group, type: :model do
   it { should validate_presence_of(:description) }
   it { should validate_presence_of(:owner_id) }
   it { should validate_presence_of(:gift_due_date) }
+  it { should validate_numericality_of(:dollar_limit).allow_nil }
+
 
   describe 'uniqueness' do
     let(:user) { User.create!(first_name: 'Larry', last_name: 'Lar', username: 'llar', password: 'pioqrey89s9ahf', password_confirmation: 'pioqrey89s9ahf') }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,8 @@ RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
+  config.include ApplicationHelper
+
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.


### PR DESCRIPTION
# Group dollar limit
This PR is dependent on #42 and addresses issue #20.


This PR adds a decimal field to the `groups` table where the dollar limit is stored. The group owner can add or edit the dollar amount and it must either be empty or greater than `0.01` 